### PR TITLE
Fix -Weffc++ warnings

### DIFF
--- a/envelope.h
+++ b/envelope.h
@@ -51,21 +51,21 @@ public:
   RESID_INLINE reg8 output();
 
 protected:
-  reg16 rate_counter;
-  reg16 rate_period;
-  reg8 exponential_counter;
-  reg8 exponential_counter_period;
-  reg8 envelope_counter;
-  bool hold_zero;
+  reg16 rate_counter = 0;
+  reg16 rate_period = 0;
+  reg8 exponential_counter = 0;
+  reg8 exponential_counter_period = 0;
+  reg8 envelope_counter = 0;
+  bool hold_zero = false;
 
-  reg4 attack;
-  reg4 decay;
-  reg4 sustain;
-  reg4 release;
+  reg4 attack = 0;
+  reg4 decay = 0;
+  reg4 sustain = 0;
+  reg4 release = 0;
 
-  reg8 gate;
+  reg8 gate = 0;
 
-  State state;
+  State state = {};
 
   // Lookup table to convert from attack, decay, or release value to rate
   // counter period.

--- a/extfilt.h
+++ b/extfilt.h
@@ -52,19 +52,19 @@ public:
 
 protected:
   // Filter enabled.
-  bool enabled;
+  bool enabled = false;
 
   // Maximum mixer DC offset.
-  sound_sample mixer_DC;
+  sound_sample mixer_DC = 0;
 
   // State of filters.
-  sound_sample Vlp; // lowpass
-  sound_sample Vhp; // highpass
-  sound_sample Vo;
+  sound_sample Vlp = 0; // lowpass
+  sound_sample Vhp = 0; // highpass
+  sound_sample Vo = 0;
 
   // Cutoff frequencies.
-  sound_sample w0lp;
-  sound_sample w0hp;
+  sound_sample w0lp = 0;
+  sound_sample w0hp = 0;
 
 friend class SID;
 };

--- a/filter.h
+++ b/filter.h
@@ -153,48 +153,50 @@ protected:
   void set_Q();
 
   // Filter enabled.
-  bool enabled;
+  bool enabled = false;
 
   // Filter cutoff frequency.
-  reg12 fc;
+  reg12 fc = 0;
 
   // Filter resonance.
-  reg8 res;
+  reg8 res = 0;
 
   // Selects which inputs to route through filter.
-  reg8 filt;
+  reg8 filt = 0;
 
   // Switch voice 3 off.
-  reg8 voice3off;
+  reg8 voice3off = 0;
 
   // Highpass, bandpass, and lowpass filter modes.
-  reg8 hp_bp_lp;
+  reg8 hp_bp_lp = 0;
 
   // Output master volume.
-  reg4 vol;
+  reg4 vol = 0;
 
   // Mixer DC offset.
-  sound_sample mixer_DC;
+  sound_sample mixer_DC = 0;
 
   // State of filter.
-  sound_sample Vhp; // highpass
-  sound_sample Vbp; // bandpass
-  sound_sample Vlp; // lowpass
-  sound_sample Vnf; // not filtered
+  sound_sample Vhp = 0; // highpass
+  sound_sample Vbp = 0; // bandpass
+  sound_sample Vlp = 0; // lowpass
+  sound_sample Vnf = 0; // not filtered
 
   // Cutoff frequency, resonance.
-  sound_sample w0, w0_ceil_1, w0_ceil_dt;
-  sound_sample _1024_div_Q;
+  sound_sample w0 = 0; 
+  sound_sample w0_ceil_1 = 0;
+  sound_sample w0_ceil_dt = 0;
+  sound_sample _1024_div_Q = 0;
 
   // Cutoff frequency tables.
   // FC is an 11 bit register.
   sound_sample f0_6581[2048];
   sound_sample f0_8580[2048];
-  sound_sample* f0;
+  sound_sample* f0 = nullptr;
   static fc_point f0_points_6581[];
   static fc_point f0_points_8580[];
-  fc_point* f0_points;
-  int f0_count;
+  fc_point* f0_points = nullptr;
+  int f0_count = 0;
 
 friend class SID;
 };

--- a/sid.h
+++ b/sid.h
@@ -31,6 +31,8 @@ class RESID_API SID
 public:
   SID();
   ~SID();
+  SID(const SID &other) = delete; // prevent copying
+  SID& operator=(const SID& other) = delete; // prevent assignment
 
   void set_chip_model(chip_model model);
   void enable_filter(bool enable);
@@ -60,18 +62,18 @@ public:
 
     char sid_register[0x20];
 
-    reg8 bus_value;
-    cycle_count bus_value_ttl;
+    reg8 bus_value = 0;
+    cycle_count bus_value_ttl = 0;
 
-    reg24 accumulator[3];
-    reg24 shift_register[3];
-    reg16 rate_counter[3];
-    reg16 rate_counter_period[3];
-    reg16 exponential_counter[3];
-    reg16 exponential_counter_period[3];
-    reg8 envelope_counter[3];
-    EnvelopeGenerator::State envelope_state[3];
-    bool hold_zero[3];
+    reg24 accumulator[3] = {};
+    reg24 shift_register[3] = {};
+    reg16 rate_counter[3] = {};
+    reg16 rate_counter_period[3] = {};
+    reg16 exponential_counter[3] = {};
+    reg16 exponential_counter_period[3] = {};
+    reg8 envelope_counter[3] = {};
+    EnvelopeGenerator::State envelope_state[3] = {};
+    bool hold_zero[3] = {};
   };
     
   State read_state();
@@ -96,19 +98,19 @@ protected:
   RESID_INLINE int clock_resample_fast(cycle_count& delta_t, short* buf,
 				       int n, int interleave);
 
-  Voice voice[3];
-  Filter filter;
-  ExternalFilter extfilt;
-  Potentiometer potx;
-  Potentiometer poty;
+  Voice voice[3] = {};
+  Filter filter = {};
+  ExternalFilter extfilt = {};
+  Potentiometer potx = {};
+  Potentiometer poty = {};
 
-  reg8 bus_value;
-  cycle_count bus_value_ttl;
+  reg8 bus_value = {};
+  cycle_count bus_value_ttl = 0;
 
-  double clock_frequency;
+  double clock_frequency = 0;
 
   // External audio input.
-  int ext_in;
+  int ext_in = 0;
 
   // Resampling constants.
   // The error in interpolated lookup is bounded by 1.234/L^2,
@@ -128,19 +130,19 @@ protected:
   static const int FIXP_MASK = 0xffff;
 
   // Sampling variables.
-  sampling_method sampling;
-  cycle_count cycles_per_sample;
-  cycle_count sample_offset;
-  int sample_index;
-  short sample_prev;
-  int fir_N;
-  int fir_RES;
+  sampling_method sampling = {};
+  cycle_count cycles_per_sample = 0;
+  cycle_count sample_offset = 0;
+  int sample_index = 0;
+  short sample_prev = 0;
+  int fir_N = 0;
+  int fir_RES = 0;
 
   // Ring buffer with overflow for contiguous storage of RINGSIZE samples.
-  short* sample;
+  short* sample = nullptr;
 
   // FIR_RES filter tables (FIR_N*FIR_RES).
-  short* fir;
+  short* fir = nullptr;
 };
 
 #endif // not __SID_H__

--- a/voice.h
+++ b/voice.h
@@ -40,14 +40,14 @@ public:
   RESID_INLINE sound_sample output();
 
 protected:
-  WaveformGenerator wave;
-  EnvelopeGenerator envelope;
+  WaveformGenerator wave = {};
+  EnvelopeGenerator envelope = {};
 
   // Waveform D/A zero level.
-  sound_sample wave_zero;
+  sound_sample wave_zero = 0;
 
   // Multiplying D/A DC offset.
-  sound_sample voice_DC;
+  sound_sample voice_DC = 0;
 
 friend class SID;
 };

--- a/wave.h
+++ b/wave.h
@@ -54,28 +54,28 @@ public:
   RESID_INLINE reg12 output();
 
 protected:
-  const WaveformGenerator* sync_source;
-  WaveformGenerator* sync_dest;
+  const WaveformGenerator* sync_source = nullptr;
+  WaveformGenerator* sync_dest = nullptr;
 
   // Tell whether the accumulator MSB was set high on this cycle.
-  bool msb_rising;
+  bool msb_rising = false;
 
-  reg24 accumulator;
-  reg24 shift_register;
+  reg24 accumulator = 0;
+  reg24 shift_register = 0;
 
   // Fout  = (Fn*Fclk/16777216)Hz
-  reg16 freq;
+  reg16 freq = 0;
   // PWout = (PWn/40.95)%
-  reg12 pw;
+  reg12 pw = 0;
 
   // The control register right-shifted 4 bits; used for output function
   // table lookup.
-  reg8 waveform;
+  reg8 waveform = 0;
 
   // The remaining control register bits.
-  reg8 test;
-  reg8 ring_mod;
-  reg8 sync;
+  reg8 test = 0;
+  reg8 ring_mod = 0;
+  reg8 sync = 0;
   // The gate bit is handled by the EnvelopeGenerator.
 
   // 16 possible combinations of waveforms.
@@ -107,10 +107,10 @@ protected:
   static reg8 wave8580_PS_[];
   static reg8 wave8580_PST[];
 
-  reg8* wave__ST;
-  reg8* wave_P_T;
-  reg8* wave_PS_;
-  reg8* wave_PST;
+  reg8* wave__ST = nullptr;
+  reg8* wave_P_T = nullptr;
+  reg8* wave_PS_ = nullptr;
+  reg8* wave_PST = nullptr;
 
 friend class Voice;
 friend class SID;


### PR DESCRIPTION
This PR:

1. Fixes the following Effective C++ warnings under Clang and GCC by making initial member values explicit:

    ![2021-04-15_20-50](https://user-images.githubusercontent.com/1557255/114978241-d3e31380-9e3d-11eb-80c8-e2474924f6e1.png)

2. Prevents the compiler from automatically creating default copy and assignment constructors for the SID class, as we don't want it copied or assigned given it contains pointers and dynamic memory (which the compiler doesn't handle in its generated defaults).
